### PR TITLE
suggested verbiage edits to the security lab

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -100,7 +100,7 @@ The DENY policy is in effect, and we are only allowing calls to be made from the
 
 ## Allow requests from `web-frontend` to `customers`
 
-When we deployed the `web-frontend`, we also created a service account for the Pod to use. Otherwise, all Pods in the namespace are assigned the default service account. A Pod's identity in Istio is a function of its associated namespace and service account.
+When we deployed the `web-frontend`, we also created a service account for the Pod to use. Otherwise, all Pods in the namespace are assigned the default service account.  Using the service account we give the Pods an identity.
 
 Use that service account to specify where the customer service calls can come from.
 


### PR DESCRIPTION
Hi Peter,

I just reviewed the QConSF security lab and along the way made edits to the verbiage which you will find in the diff below.

I tend to prefer making instructions imperative, as in "Do x, Do y.." instead of "Let's do X, or If we do y..".

At the end of the day I don't know that the edits matter very much.  Feel free to completely disregard, or to adopt only a part.

Separately, I tried to compare this lab with the Istio 0 to 60 workshop's security lab.

The QConSF security lab demonstrates the use of AuthorizationPolicy to tighten down security inside the mesh.  The Istio 0 to 60 security does too.

However the QConSF lab demonstrates the use of a deny-all policy, which is a good practice and worth discussing (though to be honest i find the flow diagram from the istio docs https://istio.io/latest/docs/concepts/security/#implicit-enablement difficult to wrap my head around).  The Istio 0 to 60 security lab does not cover this.

The Istio 0 to 60 lab however includes a section on strict mTls which is not in the QCon lab.

I also like how the Istio 0 to 60 lab, after "teaching" or "showing" how to draft an AuthorizationPolicy for the customers service, challenges the reader to come up with a second AuthorizationPolicy on their own for the web-frontend service.

I wonder why yet another security lab had to be drafted instead of just reusing the existing one?

/ Eitan
